### PR TITLE
Update to nalgebra 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ num = "0.1.*"
 
 alga = { version = "0.5.*", optional = true }
 cgmath = { version = "0.15.*", optional = true }
-nalgebra = { version = "0.13.*", optional = true }
+nalgebra = { version = "0.15.*", optional = true }
 
 [dev-dependencies]
 gfx = "0.16.*"

--- a/src/geometry/ops.rs
+++ b/src/geometry/ops.rs
@@ -248,7 +248,7 @@ mod feature_geometry_cgmath {
 
 #[cfg(feature = "geometry-nalgebra")]
 mod feature_geometry_nalgebra {
-    use alga::general::Real;
+    use nalgebra::Real;
     use nalgebra::{Point2, Point3, Scalar, Vector2, Vector3};
     use nalgebra::core::Matrix;
     use num::{Float, Num, NumCast};


### PR DESCRIPTION
This updates nalgebra to the latest 0.15. This allows Plexus to be used more easily with other libraries, such as [ncollide](http://ncollide.org/).