### PR TITLE
deps: Update `ahash` from 0.6 to 0.8.11 (latest)

### DIFF
--- a/plexus/Cargo.toml
+++ b/plexus/Cargo.toml
@@ -49,7 +49,7 @@ geometry-ultraviolet = ["theon/geometry-ultraviolet"]
 
 [dependencies]
 approx = "^0.3.0"
-ahash = "^0.6.0"
+ahash = "^0.8.11"
 arrayvec = "^0.6.0"
 decorum = "^0.3.1"
 derivative = "^2.1.1"


### PR DESCRIPTION
All versions of ahash in the 0.6 release series were yanked, so building this out of the box right now doesn't work:

```
error: failed to select a version for the requirement `ahash = "^0.6.0"`
candidate versions found which didn't match: 0.8.11, 0.8.10, 0.8.9, ...
location searched: crates.io index
required by package `plexus v0.0.11 (...)`
```