### PR TITLE
Use `resolver = "2"` with virtual workspaces.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "examples/sphere",
     "examples/subdivide",


### PR DESCRIPTION
This eliminates a warning from running `cargo` about how the virtual workspace defaults to `"1"` despite the crates in it using 2021 edition.